### PR TITLE
Read/Write images

### DIFF
--- a/lib/id3.ex
+++ b/lib/id3.ex
@@ -39,6 +39,16 @@ defmodule ID3 do
         disc: 1,
         duration: nil,
         genre: "Rock",
+        pictures: [
+          %ID3.Picture{
+            data: <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0, 1, 1, 0, 0, 72, 0,
+              72, 0, 0, 255, 225, 3, 88, 69, 120, 105, 102, 0, 0, 77, 77, 0, 42, 0, 0,
+              0, 8, 0, 9, ...>>,
+            description: "",
+            mime_type: "image/jpeg",
+            picture_type: :CoverFront
+          }
+        ],
         title: "We Will Rock You",
         total_discs: 1,
         total_tracks: 17,
@@ -61,7 +71,7 @@ defmodule ID3 do
 
   ### Examples
 
-      iex> ID3.write_tag("audio.mp3", %{%ID3.Tag{} | year: 2016})
+      iex> ID3.write_tag("audio.mp3", %{ID3.Tag.new() | year: 2016})  # removes other tags of "audio.mp3" too.
       :ok
 
   """
@@ -80,5 +90,5 @@ defmodule ID3 do
   end
 
   defp bangify!({:ok, term}), do: term
-  defp bangify!({:error, msg}), do: raise TagIOError, msg
+  defp bangify!({:error, msg}), do: raise(TagIOError, msg)
 end

--- a/lib/id3/picture.ex
+++ b/lib/id3/picture.ex
@@ -2,12 +2,20 @@ defmodule ID3.Picture do
   @moduledoc """
   A struct representing a picture in the ID3 tag.
   See https://docs.rs/id3/0.3.0/id3/frame/struct.Picture.html
+
+  ### PictureType
+  Due to limitations of `rust-id3`, multiple pictures with same `picture_type` is not available.
+  When writing, a picture with the same `picture_type` within the existing tab, will overwrite that picture.
+  When reading, `rust-id3` only returns one of the picture of the same type.
   """
 
   defstruct mime_type: nil, picture_type: nil, description: "", data: nil
 
   @typedoc """
   A structure representing an ID3 picture frame's contents.
+
+  - `data` is a binary of unsigned char(8bit)s.
+  - `picture_type` will be `:Other` otherwise correctly given.
   """
   @type t :: %__MODULE__{
           mime_type: String.t(),

--- a/lib/id3/picture.ex
+++ b/lib/id3/picture.ex
@@ -1,0 +1,62 @@
+defmodule ID3.Picture do
+  @moduledoc """
+  A struct representing a picture in the ID3 tag.
+  See https://docs.rs/id3/0.3.0/id3/frame/struct.Picture.html
+  """
+
+  defstruct mime_type: nil, picture_type: nil, description: "", data: nil
+
+  @typedoc """
+  A structure representing an ID3 picture frame's contents.
+  """
+  @type t :: %__MODULE__{
+          mime_type: String.t(),
+          picture_type: picture_type,
+          description: String.t(),
+          data: :binary
+        }
+
+  @picture_types ~W(
+    Other Icon OtherIcon
+    CoverFront CoverBack
+    Leaflet Media LeadArtist
+    Conductor Band Composer Lyricist
+    RecordingLocation DuringRecording DuringPerformance
+    ScreenCapture BrightFish
+    Illustration BandLogo PublisherLogo
+  )a
+
+  @typedoc """
+  Types of pictures used in APIC frames.
+  """
+  @type picture_type ::
+          :Other
+          | :Icon
+          | :OtherIcon
+          | :CoverFront
+          | :CoverBack
+          | :Leaflet
+          | :Media
+          | :LeadArtist
+          | :Conductor
+          | :Band
+          | :Composer
+          | :Lyricist
+          | :RecordingLocation
+          | :DuringRecording
+          | :DuringPerformance
+          | :ScreenCapture
+          | :BrightFish
+          | :Illustration
+          | :BandLogo
+          | :PublisherLogo
+
+  def new(data) when data |> is_binary do
+    %__MODULE__{
+      picture_type: :Other,
+      mime_type: "",
+      description: "",
+      data: data
+    }
+  end
+end

--- a/lib/id3/tag.ex
+++ b/lib/id3/tag.ex
@@ -40,4 +40,8 @@ defmodule ID3.Tag do
           track: non_neg_integer | nil,
           total_tracks: non_neg_integer | nil
         }
+
+  def new do
+    %{%__MODULE__{} | pictures: []}
+  end
 end

--- a/lib/id3/tag.ex
+++ b/lib/id3/tag.ex
@@ -8,7 +8,7 @@ defmodule ID3.Tag do
   defstruct [
     # :comments,
     # :lyrics,
-    # :pictures,
+    :pictures,
     :year,
     :date_recorded,
     :date_released,
@@ -26,7 +26,7 @@ defmodule ID3.Tag do
   @type t :: %__MODULE__{
           # comments: String.t() | nil,
           # lyrics: String.t() | nil,
-          # pictures: [Picture.t()],
+          pictures: [Picture.t()],
           year: integer | nil,
           date_recorded: NaiveDateTime.t() | nil,
           date_released: NaiveDateTime.t() | nil,

--- a/native/id3/src/binary/mod.rs
+++ b/native/id3/src/binary/mod.rs
@@ -10,7 +10,12 @@ impl Binary {
 impl Encoder for Binary {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         let Binary(s) = self;
+
+        // ## About `unsafe`
+        // We won't touch this as a Rust `String` beyond here,
+        // and Elixir will receive this as a `:binary`, so it is safe to do this.
         let string = unsafe { String::from_utf8_unchecked(s.to_owned()) };
+
         string.encode(env)
     }
 }

--- a/native/id3/src/binary/mod.rs
+++ b/native/id3/src/binary/mod.rs
@@ -1,0 +1,23 @@
+use rustler::{Decoder, Encoder, Env, NifResult, Term};
+
+pub struct Binary(pub Vec<u8>);
+impl Binary {
+    pub fn vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl Encoder for Binary {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        let Binary(s) = self;
+        let string = unsafe { String::from_utf8_unchecked(s.to_owned()) };
+        string.encode(env)
+    }
+}
+
+impl<'a> Decoder<'a> for Binary {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let binary = rustler::Binary::from_term(term)?;
+        Ok(Binary(binary.as_slice().to_owned()))
+    }
+}

--- a/native/id3/src/picture/mod.rs
+++ b/native/id3/src/picture/mod.rs
@@ -1,0 +1,143 @@
+use id3::frame::{Picture, PictureType};
+use rustler::types::atom::Atom as NifAtom;
+use super::binary::Binary;
+
+mod atoms {
+    rustler_atoms! {
+        atom ok;
+        atom error;
+    }
+}
+
+#[allow(non_snake_case)]
+mod pictype_atoms {
+    rustler_atoms! {
+        atom Other;
+        atom Icon;
+        atom OtherIcon;
+        atom CoverFront;
+        atom CoverBack;
+        atom Leaflet;
+        atom Media;
+        atom LeadArtist;
+        atom Artist;
+        atom Conductor;
+        atom Band;
+        atom Composer;
+        atom Lyricist;
+        atom RecordingLocation;
+        atom DuringRecording;
+        atom DuringPerformance;
+        atom ScreenCapture;
+        atom BrightFish;
+        atom Illustration;
+        atom BandLogo;
+        atom PublisherLogo;
+    }
+}
+
+#[derive(NifStruct)]
+#[module = "ID3.Picture"]
+/// Struct matching Elixir ID3's `Picture` struct.
+pub struct ID3Picture {
+    pub mime_type: String,
+    pub picture_type: NifAtom,
+    pub description: String,
+    pub data: Binary, // not a valid String, but a elixir binary.
+}
+
+impl From<&Picture> for ID3Picture {
+    fn from(pic: &Picture) -> Self {
+        Self {
+            mime_type: pic.mime_type.clone(),
+            picture_type: from_picture_type(pic.picture_type),
+            description: pic.description.clone(),
+            data: Binary(pic.data.clone()),
+        }
+    }
+}
+
+impl From<ID3Picture> for Picture {
+    fn from(pic: ID3Picture) -> Self {
+        Self {
+            mime_type: pic.mime_type,
+            picture_type: to_picture_type(pic.picture_type),
+            description: pic.description,
+            data: pic.data.vec(), //unsafe { pic.data.clone().as_mut_vec().to_vec() },
+        }
+    }
+}
+
+fn from_picture_type(pic: PictureType) -> NifAtom {
+    use id3::frame::PictureType::*;
+
+    match pic {
+        Icon => pictype_atoms::Icon(),
+        OtherIcon => pictype_atoms::OtherIcon(),
+        CoverFront => pictype_atoms::CoverFront(),
+        CoverBack => pictype_atoms::CoverBack(),
+        Leaflet => pictype_atoms::Leaflet(),
+        Media => pictype_atoms::Media(),
+        LeadArtist => pictype_atoms::LeadArtist(),
+        Artist => pictype_atoms::Artist(),
+        Conductor => pictype_atoms::Conductor(),
+        Band => pictype_atoms::Band(),
+        Composer => pictype_atoms::Composer(),
+        Lyricist => pictype_atoms::Lyricist(),
+        RecordingLocation => pictype_atoms::RecordingLocation(),
+        DuringRecording => pictype_atoms::DuringRecording(),
+        DuringPerformance => pictype_atoms::DuringPerformance(),
+        ScreenCapture => pictype_atoms::ScreenCapture(),
+        BrightFish => pictype_atoms::BrightFish(),
+        Illustration => pictype_atoms::Illustration(),
+        BandLogo => pictype_atoms::BandLogo(),
+        PublisherLogo => pictype_atoms::PublisherLogo(),
+        _ => pictype_atoms::Other(),
+    }
+}
+
+fn to_picture_type(atom: NifAtom) -> PictureType {
+    if atom == pictype_atoms::Icon() {
+        PictureType::Icon
+    } else if atom == pictype_atoms::OtherIcon() {
+        PictureType::OtherIcon
+    } else if atom == pictype_atoms::CoverFront() {
+        PictureType::CoverFront
+    } else if atom == pictype_atoms::CoverBack() {
+        PictureType::CoverBack
+    } else if atom == pictype_atoms::Leaflet() {
+        PictureType::Leaflet
+    } else if atom == pictype_atoms::Media() {
+        PictureType::Media
+    } else if atom == pictype_atoms::LeadArtist() {
+        PictureType::LeadArtist
+    } else if atom == pictype_atoms::Artist() {
+        PictureType::Artist
+    } else if atom == pictype_atoms::Conductor() {
+        PictureType::Conductor
+    } else if atom == pictype_atoms::Band() {
+        PictureType::Band
+    } else if atom == pictype_atoms::Composer() {
+        PictureType::Composer
+    } else if atom == pictype_atoms::Lyricist() {
+        PictureType::Lyricist
+    } else if atom == pictype_atoms::RecordingLocation() {
+        PictureType::RecordingLocation
+    } else if atom == pictype_atoms::DuringRecording() {
+        PictureType::DuringRecording
+    } else if atom == pictype_atoms::DuringPerformance() {
+        PictureType::DuringPerformance
+    } else if atom == pictype_atoms::ScreenCapture() {
+        PictureType::ScreenCapture
+    } else if atom == pictype_atoms::BrightFish() {
+        PictureType::BrightFish
+    } else if atom == pictype_atoms::Illustration() {
+        PictureType::Illustration
+    } else if atom == pictype_atoms::BandLogo() {
+        PictureType::BandLogo
+    } else if atom == pictype_atoms::PublisherLogo() {
+        PictureType::PublisherLogo
+    } else {
+        PictureType::Other
+    }
+}


### PR DESCRIPTION
Returns id3 frame pictures as `:binary`s!! :tada:
`:binary`s are used by default on `File.open/2,3,4` and `File.read`s, so you can open an image file and pass it to the ID3 tag.

Documents are updated too.