### PR TITLE
Better piping with Tag edit functions

### DIFF
--- a/lib/id3.ex
+++ b/lib/id3.ex
@@ -71,14 +71,14 @@ defmodule ID3 do
 
   ### Examples
 
-      iex> ID3.write_tag("audio.mp3", %{ID3.Tag.new() | year: 2016})  # removes other tags of "audio.mp3" too.
+      iex> ID3.write_tag(%{ID3.Tag.new() | year: 2016}, "audio.mp3")  # removes other tags of "audio.mp3" too.
       :ok
 
   """
-  @spec write_tag(Path.t(), Tag.t()) :: :ok | {:error, :file_open_error | :tag_write_error}
-  defdelegate write_tag(path, tag), to: Native, as: :write_major_frames
+  @spec write_tag(Tag.t(), Path.t()) :: :ok | {:error, :file_open_error | :tag_write_error}
+  defdelegate write_tag(tag, path), to: Native, as: :write_major_frames
 
-  def write_tag!(path, tag), do: write_tag(path, tag) |> bangify!
+  def write_tag!(tag, path), do: write_tag(tag, path) |> bangify!
 
   defmodule TagIOError do
     defexception [:message]

--- a/lib/id3/native.ex
+++ b/lib/id3/native.ex
@@ -15,7 +15,7 @@ defmodule ID3.Native do
   @spec get_major_frames(Path.t()) :: {:ok, ID3.Tag.t()} | {:error, :file_open_error}
   def get_major_frames(_path), do: :erlang.nif_error(:nif_not_loaded)
 
-  @spec write_major_frames(Path.t(), Tag.t()) ::
+  @spec write_major_frames(Tag.t(), Path.t()) ::
           :ok | {:error, :file_open_error | :tag_write_error}
-  def write_major_frames(_path, %Tag{} = _frames), do: :erlang.nif_error(:nif_not_loaded)
+  def write_major_frames(%Tag{} = _frames, _path), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/id3/tag.ex
+++ b/lib/id3/tag.ex
@@ -5,6 +5,8 @@ defmodule ID3.Tag do
   This struct must match / be matched by the Rust Nif's struct.
   """
 
+  alias ID3.Picture
+
   defstruct [
     # :comments,
     # :lyrics,
@@ -43,5 +45,14 @@ defmodule ID3.Tag do
 
   def new do
     %{%__MODULE__{} | pictures: []}
+  end
+
+  def put_picture(%__MODULE__{} = tag, %Picture{picture_type: type} = picture) do
+    pictures =
+      tag.pictures
+      |> Enum.reject(fn %Picture{picture_type: pt} -> pt == type end)
+      |> List.insert_at(0, picture)
+
+    %{tag | pictures: pictures}
   end
 end

--- a/native/id3/src/lib.rs
+++ b/native/id3/src/lib.rs
@@ -79,8 +79,8 @@ fn major_frames<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
 }
 
 fn write_major_frames<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let path: String = args[0].decode()?;
-    let frames: MajorFrames = args[1].decode()?;
+    let frames: MajorFrames = args[0].decode()?;
+    let path: String = args[1].decode()?;
 
     match Tag::read_from_path(&path) {
         Ok(tag) => {


### PR DESCRIPTION
- Add function to edit tag's lists
- Change `ID3.write_tag/2` to accept tag from pipes
  - before: `write_tag(path, tag)`
  - after: `write_tag(tag, path)`
  - This is a BREAKING CHANGE.